### PR TITLE
changed line graph point colors again to match key

### DIFF
--- a/client/src/components/Charts/LineChart.js
+++ b/client/src/components/Charts/LineChart.js
@@ -38,8 +38,8 @@ function LineChart (props) {
                 label: 'Sleep',
                 backgroundColor: 'rgba(255,255,255,0.2)',
                 borderColor: 'rgba(140, 6, 224,1)',
-                  hoverBackgroundColor: 'rgba(140, 6, 224,1)',
-                  hoverBorderColor: 'rgba(140, 6, 224,1)',
+                hoverBackgroundColor: 'rgba(140, 6, 224,1)',
+                hoverBorderColor: 'rgba(140, 6, 224,1)',
                 borderWidth: 2,
                 data: sleep
                 
@@ -49,8 +49,6 @@ function LineChart (props) {
                 backgroundColor: 'rgba(255,99,132,0.2)',
                 borderColor: 'rgba(255,99,132,1)',
                 borderWidth: 1,
-                hoverBackgroundColor: 'rgba(114, 191, 63, 0.52)',
-                hoverBorderColor: 'rgb(93, 142, 61)',
                 data: mood
         
             },
@@ -59,8 +57,6 @@ function LineChart (props) {
                 backgroundColor: 'rgba(83, 181, 181, 0.4)',
                 borderColor: 'rgba(41, 182, 182, 0.77)',
                 borderWidth: 1,
-                hoverBackgroundColor: 'rgba(236, 230, 64, 0.44)',
-                hoverBorderColor: 'rgba(236, 230, 64, 0.82)',
                 data: anxiety
             },
             {
@@ -68,8 +64,6 @@ function LineChart (props) {
                 backgroundColor: 'rgba(41, 142, 182, 0.29)',
                 borderColor: 'rgba(41, 142, 182, 0.8)',
                 borderWidth: 1,
-                hoverBackgroundColor: 'rgba(241, 28, 138, 0.6)',
-                hoverBorderColor: 'rgb(241, 28, 138)',
                 data: energy
             }
           ] 

--- a/client/src/pages/Dashboard/Dashboard.js
+++ b/client/src/pages/Dashboard/Dashboard.js
@@ -149,9 +149,9 @@ class Dashboard extends React.Component {
                 userID={this.props.userID}
               />}
             </div>
-            <div className="col-5">
+            {/* <div className="col-5">
               <PersonalTabs userID={this.props.userID}/>
-            </div>  
+            </div>   */}
           </div>
         </div>
       </div>


### PR DESCRIPTION
I had changed this before, but apparently it got overwritten. I changed the colors so that when you hover over the points in the line chart, the colors match the legend.